### PR TITLE
Fix double start triggered by overlapping click handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,9 +787,9 @@ const introGo=document.getElementById('introGo');
 
 /* -------------------- Bindings -------------------- */
 function bind(){
-  startGameBtn.addEventListener('click',startGame);
-  playerName.addEventListener('keydown',e=>{ if(e.key==='Enter') startGame(); });
-  startLevelBtn.addEventListener('click',handleStartLevelClick);
+  startGameBtn.addEventListener('click',e=>{ e.preventDefault(); startGame(); });
+  playerName.addEventListener('keydown',e=>{ if(e.key==='Enter'){ e.preventDefault(); startGame(); } });
+  startLevelBtn.addEventListener('click',e=>{ e.preventDefault(); handleStartLevelClick(); });
   introGo.addEventListener('click',startLevelRun);
   pauseBtn.addEventListener('click',togglePause);
   resumeBtn.addEventListener('click',togglePause);
@@ -831,12 +831,6 @@ function init(){
     try {
       bind();
       init();
-      document.addEventListener('click', (e) => {
-        const t = e.target;
-        if (!t) return;
-        if (t.id === 'startGameBtn') { e.preventDefault(); startGame(); }
-        if (t.id === 'startLevelBtn') { e.preventDefault(); handleStartLevelClick(); }
-      }, { capture: true });
     } catch (err) { console.error('Init error:', err); }
   });
 })();


### PR DESCRIPTION
## Summary
- Prevent starting game twice by removing redundant document-level click handler
- Ensure Start buttons prevent default and trigger game logic once

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd1b4e9f08329b050cca7d31090f8