### PR TITLE
Add leaderboard week() test and fix date range

### DIFF
--- a/index.html
+++ b/index.html
@@ -777,7 +777,14 @@ function record(run){ const a=loadRuns(); a.unshift(run); a.sort((x,y)=>y.s-x.s 
 function previewLB(){
   const a=loadRuns(); leaderboardPreview.innerHTML = a.length? a.slice(0,3).map((r,i)=>`${i+1}. ${escapeHTML(r.n)} — ${r.s} pts — ${fmt(r.t)}`).join('<br/>') : "Be the first champion! 🌱";
 }
-function week(ts){ const d=new Date(ts), now=new Date(); const day=now.getDay(); const monday=new Date(now.getFullYear(),now.getMonth(),now.getDate()-((day+6)%7)); return d>=monday; }
+function week(ts){
+  const d=new Date(ts), now=new Date();
+  const day=now.getDay();
+  const monday=new Date(now.getFullYear(),now.getMonth(),now.getDate()-((day+6)%7));
+  const next=new Date(monday);
+  next.setDate(monday.getDate()+7);
+  return d>=monday && d<next;
+}
 function showLB(filter='all'){
   const all=loadRuns(); let list=[];
   if(filter==='all') list=all; else if(filter==='week') list=all.filter(r=>week(r.ts)); else if(filter==='you') list=all.filter(r=>r.n===name);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "charlies-lawn-mowing-adventure",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/leaderboard.test.js"
+  }
+}

--- a/tests/leaderboard.test.js
+++ b/tests/leaderboard.test.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+
+function week(ts) {
+  const d = new Date(ts), now = new Date();
+  const day = now.getDay();
+  const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - ((day + 6) % 7));
+  const nextMonday = new Date(monday);
+  nextMonday.setDate(monday.getDate() + 7);
+  return d >= monday && d < nextMonday;
+}
+
+// Timestamp within the current week should be true
+assert.strictEqual(week(Date.now()), true);
+
+// Timestamp from previous week should be false
+const prev = new Date();
+prev.setDate(prev.getDate() - 7);
+assert.strictEqual(week(prev.getTime()), false);
+
+// Timestamp from upcoming week should be false
+const next = new Date();
+next.setDate(next.getDate() + 7);
+assert.strictEqual(week(next.getTime()), false);
+
+console.log('leaderboard week() tests passed');


### PR DESCRIPTION
## Summary
- add Node-based tests for leaderboard week filter
- fix week() to exclude dates beyond the current week

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd8e755208329b14aaf8d73f08e61