### PR TITLE
End run on obstacle collision

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,6 +469,7 @@ function frame(ts){
 }
 function step(d){
   handle(d); move(d); eatGrass(); pickPower(); collide();
+  if(!running) return;
   tickPowers(d); tickObs(d); tickWeather(d); total+=d; ui(); winCheck(); timeCheck();
 }
 function handle(d){
@@ -513,7 +514,8 @@ function collide(){
 
       setComment(`Easy there. Go around the ${o.t}.`);
       vibr(25);
-      break;
+      gameOver();
+      return;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Stop level immediately when mower hits an obstacle by triggering `gameOver()`
- Skip win/time checks if the game is no longer running

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bddacb5648329af7cfb6298d3dbcf