### PR TITLE
Add success overlay styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
            border:2px solid rgba(255,255,255,.35);border-radius:16px;max-width:min(720px,95vw);margin:auto;padding:20px;box-shadow:0 10px 40px rgba(0,0,0,.32)}
   .overlay.crash{background:rgba(255,235,238,.96);border-color:rgba(244,67,54,.35)}
   .overlay.crash h2{color:#c62828}
+  .overlay.complete{background:rgba(232,245,233,.96);border-color:rgba(76,175,80,.35)}
   .leader-filters{display:flex;gap:8px;justify-content:center;margin-bottom:8px}
   .filter{background:linear-gradient(135deg,var(--accent),#388E3C);color:#fff;border:none;border-radius:9px;padding:8px 12px;font-weight:800}
   .filter.active{background:linear-gradient(135deg,var(--brand),#F7931E)}
@@ -174,7 +175,7 @@
 </div>
 
 <!-- Overlays -->
-<div class="overlay" id="ovComplete">
+<div class="overlay complete" id="ovComplete">
   <h2>Level Complete! 🎉</h2>
   <p id="ovCongrats" style="font-weight:700"></p>
   <p>Time: <span id="ovTime">0:00</span></p>


### PR DESCRIPTION
## Summary
- style level-complete overlay with a green background and border
- use the new `overlay complete` class on the level-complete overlay
- keep obstacle crashes applying the red `crash` style for game over

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689be3c275b883299b3c9bde603e8e43