### PR TITLE
Tighten overlay layout for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
   .comment{background:rgba(255,248,220,.95);border:2px solid rgba(255,215,0,.35);border-radius:10px;padding:8px;font-style:italic}
 
   .overlay{display:none;position:fixed;inset:0;background:rgba(255,255,255,.96);backdrop-filter:blur(10px);z-index:20;
-           border:2px solid rgba(255,255,255,.35);border-radius:16px;max-width:min(720px,95vw);margin:auto;padding:20px;box-shadow:0 10px 40px rgba(0,0,0,.32)}
+           border:2px solid rgba(255,255,255,.35);border-radius:16px;max-width:min(480px,90vw);margin:auto;padding:16px;box-shadow:0 10px 40px rgba(0,0,0,.32)}
   .overlay.crash{background:rgba(255,235,238,.96);border-color:rgba(244,67,54,.35)}
   .overlay.crash h2{color:#c62828}
   .leader-filters{display:flex;gap:8px;justify-content:center;margin-bottom:8px}


### PR DESCRIPTION
## Summary
- Reduce overlay max width and padding for tighter mobile overlays.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be3bcdcd48329b6f7669b93593f5a