### PR TITLE
Use image assets for obstacles and power-ups

### DIFF
--- a/assets/barrel.svg
+++ b/assets/barrel.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="8" width="16" height="16" fill="#8B4513" />
+  <line x1="8" y1="12" x2="24" y2="12" stroke="#000" stroke-width="2" />
+  <line x1="8" y1="20" x2="24" y2="20" stroke="#000" stroke-width="2" />
+</svg>

--- a/assets/bike.svg
+++ b/assets/bike.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="10" cy="22" r="6" stroke="#000" stroke-width="2" fill="none" />
+  <circle cx="22" cy="22" r="6" stroke="#000" stroke-width="2" fill="none" />
+  <path d="M10 22l6-8 6 8-4-8h-4" stroke="#000" stroke-width="2" fill="none" />
+</svg>

--- a/assets/bucket.svg
+++ b/assets/bucket.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="10" width="16" height="14" fill="#1e90ff" />
+  <path d="M8 10a8 8 0 0 1 16 0" stroke="#1e90ff" stroke-width="2" fill="none" />
+</svg>

--- a/assets/bud.svg
+++ b/assets/bud.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="10" width="12" height="14" fill="#fdd835" />
+  <rect x="20" y="12" width="4" height="10" fill="#fdd835" />
+  <rect x="8" y="8" width="12" height="4" fill="#fff" />
+</svg>

--- a/assets/chair.svg
+++ b/assets/chair.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="12" width="16" height="4" fill="#ccc" />
+  <rect x="10" y="16" width="2" height="8" fill="#ccc" />
+  <rect x="20" y="16" width="2" height="8" fill="#ccc" />
+</svg>

--- a/assets/flamingo.svg
+++ b/assets/flamingo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="12" r="8" fill="#ff69b4" />
+  <rect x="15" y="20" width="2" height="8" fill="#ff69b4" />
+</svg>

--- a/assets/fountain.svg
+++ b/assets/fountain.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="10" fill="#87cefa" />
+  <rect x="10" y="22" width="12" height="4" fill="#87cefa" />
+</svg>

--- a/assets/gnome.svg
+++ b/assets/gnome.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <polygon points="16,4 22,16 10,16" fill="#b5651d" />
+  <circle cx="16" cy="22" r="8" fill="#800080" />
+</svg>

--- a/assets/golf.svg
+++ b/assets/golf.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="4" y="20" width="24" height="6" fill="#228B22" />
+  <circle cx="16" cy="18" r="4" fill="#fff" stroke="#ccc" />
+</svg>

--- a/assets/grill.svg
+++ b/assets/grill.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="6" y="12" width="20" height="12" fill="#444" />
+  <rect x="6" y="10" width="20" height="4" fill="#c00" />
+</svg>

--- a/assets/house.svg
+++ b/assets/house.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="12" y="28" width="40" height="28" fill="#f5deb3" />
+  <polygon points="12,28 32,12 52,28" fill="#d2691e" />
+  <rect x="28" y="40" width="8" height="16" fill="#8b4513" />
+</svg>

--- a/assets/leaf.svg
+++ b/assets/leaf.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <path d="M16 4c-6 4-10 10-10 18 6 0 12-4 14-8 2-4 2-8-4-10z" fill="#4caf50" />
+</svg>

--- a/assets/rock.svg
+++ b/assets/rock.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="20" r="10" fill="#888" />
+</svg>

--- a/assets/shed.svg
+++ b/assets/shed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="6" y="12" width="20" height="14" fill="#a0522d" />
+  <polygon points="6,12 16,4 26,12" fill="#8b4513" />
+</svg>

--- a/assets/sprinkler.svg
+++ b/assets/sprinkler.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="12" y="20" width="8" height="8" fill="#555" />
+  <path d="M8 16a8 8 0 0 1 16 0" stroke="#00f" stroke-width="2" fill="none" />
+</svg>

--- a/assets/tree.svg
+++ b/assets/tree.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="14" y="18" width="4" height="10" fill="#8B4513" />
+  <circle cx="16" cy="14" r="10" fill="#228B22" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -366,6 +366,17 @@ const rc=a=>a[Math.floor(Math.random()*a.length)];
 const fmt=s=>{const m=Math.floor(s/60),sec=Math.floor(s%60);return `${m}:${sec<10?"0":""}${sec}`};
 const hit=(a,b)=>!(a.x+a.w<b.x||a.x>b.x+b.w||a.y+a.h<b.y||a.y>b.y+b.h);
 
+const IMGS={};
+function preloadImages(){
+  const names=['rock','tree','sprinkler','gnome','flamingo','grill','chair','bucket','bike','barrel','shed','fountain','bud','golf','leaf','house'];
+  for(const n of names){
+    const img=new Image();
+    img.src=`assets/${n}.svg`;
+    IMGS[n]=img;
+  }
+}
+preloadImages();
+
 /* -------------------- Input -------------------- */
 addEventListener('keydown',e=>{
   const block=['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','KeyW','KeyA','KeyS','KeyD','Space'];
@@ -524,7 +535,14 @@ function collide(){
 }
 function pickPower(){ for(const p of powerUps){ if(p.a&&hit(mower,p)){ p.a=false; power(p.t); } } }
 function tickPowers(d){ for(const p of powerUps){ if(p.a){ p.tt-=d; if(p.tt<=0) p.a=false; } } }
-function tickObs(d){ for(const o of obs){ if(!o.a) continue; if(o.t==='tree'){ o.s=(o.s||0)+d; o.off=Math.sin(o.s)*2 } if(o.t==='sprinkler') o.r=(o.r||0)+3*d; } }
+function tickObs(d){
+  for(const o of obs){
+    if(!o.img) o.img = IMGS[o.t];
+    if(!o.a) continue;
+    if(o.t==='tree'){ o.s=(o.s||0)+d; o.off=Math.sin(o.s)*2 }
+    if(o.t==='sprinkler') o.r=(o.r||0)+3*d;
+  }
+}
 function tickWeather(d){ weather.t-=d; if(weather.t<=0){ weather.type=rc(['sun','rain','wind']); weather.t=ri(12,22); weath(); } }
 function winCheck(){
   const totalTiles=tiles.length, mowed=tiles.reduce((n,t)=>n+(t.m?1:0),0);
@@ -547,16 +565,16 @@ function spawnBud(){
   for(let tries=0; tries<40; tries++){
     const p={x:ri(20,BASE_W-44), y:ri(20,BASE_H-44), w:24, h:24};
     const overlapsObs = obs.some(o=>o.a && hit(p,o)) || hit(p,start);
-    if(!overlapsObs){ powerUps.push({t:'bud',i:'🍺',x:p.x,y:p.y,w:24,h:24,a:true,tt:18}); return; }
+    if(!overlapsObs){ powerUps.push({t:'bud',img:IMGS.bud,x:p.x,y:p.y,w:24,h:24,a:true,tt:18}); return; }
   }
-  powerUps.push({t:'bud',i:'🍺',x:ri(20,BASE_W-40),y:ri(20,BASE_H-40),w:24,h:24,a:true,tt:18});
+  powerUps.push({t:'bud',img:IMGS.bud,x:ri(20,BASE_W-40),y:ri(20,BASE_H-40),w:24,h:24,a:true,tt:18});
 }
 function setup(level){
   tiles=[]; powerUps=[]; obs=[];
   mower={x:50,y:50,w:16,h:16,spd:120,acc:350,vx:0,vy:0,boost:false,inv:false};
   introShown=false; clearBudTimer();
 
-  const house={t:'house',i:'🏠',a:true,x:260,y:20,w:110,h:90};
+  const house={t:'house',img:IMGS.house,a:true,x:260,y:20,w:110,h:90};
   obs.push(house);
 
   const ts=20, cols=Math.floor(BASE_W/ts), rows=Math.floor(BASE_H/ts);
@@ -567,15 +585,15 @@ function setup(level){
     tiles.push(tile);
   }
 
-  const kinds=[['rock','🪨',26,26],['tree','🌳',30,30],['sprinkler','💦',26,26],['gnome','🧙‍♂️',26,26],['flamingo','🦩',28,28],['grill','🔥',26,26],['chair','🪑',26,26],['bucket','🪣',26,26],['bike','🚲',32,24],['barrel','🛢️',26,26],['shed','🏚️',34,28],['fountain','⛲',28,28]];
+  const kinds=[['rock',26,26],['tree',30,30],['sprinkler',26,26],['gnome',26,26],['flamingo',28,28],['grill',26,26],['chair',26,26],['bucket',26,26],['bike',32,24],['barrel',26,26],['shed',34,28],['fountain',28,28]];
   const n=6+Math.min(level,4);
   for(let i=0;i<n;i++){
     const k=rc(kinds); let tries=0, placed=false;
     while(!placed && tries<28){
       const x=ri(40,BASE_W-60), y=ri(50,BASE_H-60);
-      const cand={x,y,w:k[2],h:k[3]}; const start={x:0,y:0,w:100,h:100};
+      const cand={x,y,w:k[1],h:k[2]}; const start={x:0,y:0,w:100,h:100};
       if(hit(cand,start) || hit(cand,house)) {tries++; continue;}
-      obs.push({t:k[0],i:k[1],a:true,x,y,w:cand.w,h:cand.h});
+      obs.push({t:k[0],img:IMGS[k[0]],a:true,x,y,w:cand.w,h:cand.h});
       tiles=tiles.filter(t=>!hit(t,cand));
       placed=true;
     }
@@ -583,8 +601,8 @@ function setup(level){
 
   // Other powerups
   const rnd=()=>({x:ri(60,BASE_W-60),y:ri(70,BASE_H-80)});
-  if(Math.random()<.5){const p=rnd(); powerUps.push({t:'golf',i:'🚗',x:p.x,y:p.y,w:24,h:24,a:true,tt:18});}
-  if(Math.random()<.4){const p=rnd(); powerUps.push({t:'leaf',i:'🍃',x:p.x,y:p.y,w:24,h:24,a:true,tt:18});}
+  if(Math.random()<.5){const p=rnd(); powerUps.push({t:'golf',img:IMGS.golf,x:p.x,y:p.y,w:24,h:24,a:true,tt:18});}
+  if(Math.random()<.4){const p=rnd(); powerUps.push({t:'leaf',img:IMGS.leaf,x:p.x,y:p.y,w:24,h:24,a:true,tt:18});}
 
   // Budweiser boobster every 10s
   spawnBud(); budTimer=setInterval(spawnBud, 10000);
@@ -615,14 +633,14 @@ function draw(){
     ctx.save();
     if(o.t==='sprinkler'){
       o.r=(o.r||0)+.04; ctx.translate(o.x+o.w/2,o.y+o.h/2); ctx.rotate(o.r);
-      drawEmoji('💦',-12,10,28); ctx.restore(); continue;
+      ctx.drawImage(o.img, -o.w/2, -o.h/2, o.w, o.h); ctx.restore(); continue;
     }
     ctx.fillStyle="rgba(0,0,0,.14)"; roundRect(o.x-2,o.y-2,o.w+4,o.h+4,6); ctx.fill();
-    drawEmoji(o.i, o.x+o.w*0.14, o.y+o.h*0.78, Math.max(o.w,o.h));
+    ctx.drawImage(o.img, o.x, o.y, o.w, o.h);
     ctx.restore();
   }
 
-  for(const p of powerUps){ if(p.a){ ctx.save(); ctx.translate(p.x+12,p.y+12); ctx.rotate((Date.now()/500)%(Math.PI*2)); drawEmoji(p.i,-8,8,22); ctx.restore(); } }
+  for(const p of powerUps){ if(p.a){ ctx.save(); ctx.translate(p.x+p.w/2,p.y+p.h/2); ctx.rotate((Date.now()/500)%(Math.PI*2)); ctx.drawImage(p.img,-p.w/2,-p.h/2,p.w,p.h); ctx.restore(); } }
 
   drawMower();
 
@@ -630,11 +648,6 @@ function draw(){
     ctx.fillStyle="rgba(0,0,255,.08)"; ctx.fillRect(0,0,BASE_W,BASE_H);
     for(let i=0;i<14;i++){ const x=(Date.now()/10+i*50)%BASE_W, y=(Date.now()/5+i*30)%BASE_H; ctx.fillStyle="rgba(173,216,230,.7)"; ctx.fillRect(x,y,2,8) }
   }else if(weather.type==="wind"){ ctx.fillStyle="rgba(200,200,200,.08)"; ctx.fillRect(0,0,BASE_W,BASE_H); }
-}
-function drawEmoji(e,x,y,size){
-  ctx.font=`${Math.floor(size)}px "Segoe UI Emoji","Apple Color Emoji","Noto Color Emoji",system-ui,Arial`;
-  ctx.lineWidth=3; ctx.strokeStyle='rgba(255,255,255,.85)';
-  ctx.strokeText(e,x,y); ctx.fillText(e,x,y);
 }
 function roundRect(x,y,w,h,r){ ctx.beginPath(); ctx.moveTo(x+r,y); ctx.arcTo(x+w,y,x+w,y+h,r); ctx.arcTo(x+w,y+h,x,y+h,r); ctx.arcTo(x,y+h,x,y,r); ctx.arcTo(x,y,x+w,y,r); ctx.closePath(); }
 function drawMower(){


### PR DESCRIPTION
## Summary
- Add SVG image files for all obstacles and power-ups
- Preload images and assign them during obstacle and power-up generation
- Draw obstacles and power-ups with `ctx.drawImage`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be7f0f1c483299a47a06ded5f2600