### PR TITLE
Add obstacle and power-up assets

### DIFF
--- a/assets/obstacles/barrel.svg
+++ b/assets/obstacles/barrel.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="8" width="16" height="20" rx="4" fill="#8B4513"/>
+  <line x1="8" y1="14" x2="24" y2="14" stroke="#654321" stroke-width="2"/>
+  <line x1="8" y1="22" x2="24" y2="22" stroke="#654321" stroke-width="2"/>
+</svg>

--- a/assets/obstacles/bike.svg
+++ b/assets/obstacles/bike.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="10" cy="24" r="6" stroke="#000" fill="none" stroke-width="2"/>
+  <circle cx="24" cy="24" r="6" stroke="#000" fill="none" stroke-width="2"/>
+  <line x1="10" y1="24" x2="16" y2="14" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="14" x2="24" y2="24" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="14" x2="20" y2="24" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="14" x2="24" y2="14" stroke="#000" stroke-width="2"/>
+  <line x1="24" y1="14" x2="28" y2="12" stroke="#000" stroke-width="2"/>
+</svg>

--- a/assets/obstacles/bucket.svg
+++ b/assets/obstacles/bucket.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <path d="M10 8h12l-2 20H12L10 8z" fill="#aaa"/>
+  <path d="M12 8c0-4 8-4 8 0" stroke="#888" fill="none" stroke-width="2"/>
+</svg>

--- a/assets/obstacles/chair.svg
+++ b/assets/obstacles/chair.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="14" width="16" height="6" fill="#b5651d"/>
+  <rect x="8" y="8" width="16" height="4" fill="#b5651d"/>
+  <line x1="10" y1="20" x2="10" y2="28" stroke="#b5651d" stroke-width="2"/>
+  <line x1="22" y1="20" x2="22" y2="28" stroke="#b5651d" stroke-width="2"/>
+</svg>

--- a/assets/obstacles/flamingo.svg
+++ b/assets/obstacles/flamingo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="20" rx="8" ry="6" fill="#f6a"/>
+  <path d="M12 18c0-8 12-8 12-2" stroke="#f6a" stroke-width="2" fill="none"/>
+  <circle cx="24" cy="12" r="3" fill="#f6a"/>
+  <line x1="12" y1="26" x2="12" y2="30" stroke="#f6a" stroke-width="2"/>
+</svg>

--- a/assets/obstacles/fountain.svg
+++ b/assets/obstacles/fountain.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="24" width="16" height="4" fill="#999"/>
+  <circle cx="16" cy="20" r="6" stroke="#55f" stroke-width="2" fill="none"/>
+  <path d="M16 20c0-8-4-8-4-12" stroke="#55f" stroke-width="2" fill="none"/>
+  <path d="M16 20c0-8 4-8 4-12" stroke="#55f" stroke-width="2" fill="none"/>
+</svg>

--- a/assets/obstacles/gnome.svg
+++ b/assets/obstacles/gnome.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <polygon points="16,2 6,14 26,14" fill="#c00"/>
+  <rect x="10" y="20" width="12" height="10" fill="#00f"/>
+  <circle cx="16" cy="16" r="4" fill="#fdd"/>
+  <path d="M16 20c-3 0-6 2-6 5h12c0-3-3-5-6-5z" fill="#fff"/>
+</svg>

--- a/assets/obstacles/grill.svg
+++ b/assets/obstacles/grill.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="14" r="10" fill="#333"/>
+  <line x1="12" y1="20" x2="10" y2="30" stroke="#333" stroke-width="2"/>
+  <line x1="20" y1="20" x2="22" y2="30" stroke="#333" stroke-width="2"/>
+  <rect x="10" y="24" width="12" height="4" fill="#c00"/>
+</svg>

--- a/assets/obstacles/rock.svg
+++ b/assets/obstacles/rock.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="20" rx="12" ry="8" fill="#888"/>
+</svg>

--- a/assets/obstacles/shed.svg
+++ b/assets/obstacles/shed.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <polygon points="6,14 16,4 26,14" fill="#b22222"/>
+  <rect x="8" y="14" width="16" height="14" fill="#deb887"/>
+  <rect x="14" y="20" width="4" height="8" fill="#654321"/>
+</svg>

--- a/assets/obstacles/sprinkler.svg
+++ b/assets/obstacles/sprinkler.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="12" y="18" width="8" height="8" fill="#666"/>
+  <path d="M16 18c-6-4-10 0-10-4" stroke="#55f" fill="none" stroke-width="2"/>
+  <path d="M16 18c6-4 10 0 10-4" stroke="#55f" fill="none" stroke-width="2"/>
+</svg>

--- a/assets/obstacles/tree.svg
+++ b/assets/obstacles/tree.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="14" y="16" width="4" height="10" fill="#8B5A2B"/>
+  <circle cx="16" cy="12" r="10" fill="#228B22"/>
+</svg>

--- a/assets/powerups/bud.svg
+++ b/assets/powerups/bud.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="12" y="4" width="8" height="24" rx="2" fill="#c00"/>
+  <rect x="12" y="14" width="8" height="4" fill="#fff"/>
+</svg>

--- a/assets/powerups/golf-cart.svg
+++ b/assets/powerups/golf-cart.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="8" y="14" width="16" height="8" fill="#ddd"/>
+  <rect x="8" y="10" width="12" height="4" fill="#ddd"/>
+  <line x1="8" y1="14" x2="8" y2="10" stroke="#000" stroke-width="2"/>
+  <line x1="20" y1="14" x2="20" y2="10" stroke="#000" stroke-width="2"/>
+  <circle cx="12" cy="24" r="4" fill="#000"/>
+  <circle cx="24" cy="24" r="4" fill="#000"/>
+</svg>

--- a/assets/powerups/leaf.svg
+++ b/assets/powerups/leaf.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <path d="M4 20 Q16 4 28 20 Q16 28 4 20Z" fill="#2e8b57"/>
+  <line x1="16" y1="10" x2="16" y2="24" stroke="#1e6b37" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `assets/obstacles` and `assets/powerups` directories
- include basic SVG icons for rocks, trees, sprinklers, gnomes, flamingos, grills, chairs, buckets, bikes, barrels, sheds, fountains
- add power-up icons for Budweiser, golf cart, and leaf blower

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf54356108329aed165ea84e93b99