### PR TITLE
Add inline SVG power-up icons and update count rendering

### DIFF
--- a/assets/powerups/bud.svg
+++ b/assets/powerups/bud.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 32 32">
   <rect x="12" y="4" width="8" height="24" rx="2" fill="#c00"/>
   <rect x="12" y="14" width="8" height="4" fill="#fff"/>
 </svg>

--- a/assets/powerups/golf-cart.svg
+++ b/assets/powerups/golf-cart.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 32 32">
   <rect x="8" y="14" width="16" height="8" fill="#ddd"/>
   <rect x="8" y="10" width="12" height="4" fill="#ddd"/>
   <line x1="8" y1="14" x2="8" y2="10" stroke="#000" stroke-width="2"/>

--- a/assets/powerups/leaf.svg
+++ b/assets/powerups/leaf.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 32 32">
   <path d="M4 20 Q16 4 28 20 Q16 28 4 20Z" fill="#2e8b57"/>
   <line x1="16" y1="10" x2="16" y2="24" stroke="#1e6b37" stroke-width="2"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
 <meta name="description" content="Help Charlie mow lawns in this mobile-friendly comedy game. 12 levels, power ups, obstacles, and a local leaderboard." />
 <meta property="og:title" content="Charlie's Lawn Mowing Adventure – The Game" />
 <meta property="og:description" content="Play this mobile-friendly lawn mowing game with 12 levels, power ups, obstacles, and a local leaderboard." />
+<link rel="preload" href="assets/powerups/bud.svg" as="image" type="image/svg+xml">
+<link rel="preload" href="assets/powerups/golf-cart.svg" as="image" type="image/svg+xml">
+<link rel="preload" href="assets/powerups/leaf.svg" as="image" type="image/svg+xml">
 <style>
   :root{
     --bg1:#0C2340; --bg2:#1F3B73; --bg3:#B9975B; --sky:#87CEEB;
@@ -93,7 +96,8 @@
   .filter{background:linear-gradient(135deg,var(--accent),var(--accent-dark));color:#fff;border:none;border-radius:9px;padding:8px 12px;font-weight:800}
   .filter.active{background:linear-gradient(135deg,var(--brand),var(--accent))}
   .power-slots{display:flex;gap:10px;justify-content:center}
-  .slot{background:#fff;border:2px solid rgba(0,0,0,.08);border-radius:10px;padding:6px 10px;font-weight:900}
+  .slot{background:#fff;border:2px solid rgba(0,0,0,.08);border-radius:10px;padding:6px 10px;font-weight:900;display:flex;align-items:center;gap:4px}
+  .power-slots .icon{width:1.2em;height:1.2em}
   .timers{display:flex;gap:10px;justify-content:center;flex-wrap:wrap}
   .mute{font-size:1.4rem;background:none;border:none}
 
@@ -161,9 +165,9 @@
     <canvas id="gameCanvas" width="400" height="300" aria-label="Game field" role="img"></canvas>
 
     <div class="power-slots">
-      <div class="slot">🍺 <span id="c-bud">0</span></div>
-      <div class="slot">🚗 <span id="c-golf">0</span></div>
-      <div class="slot">🍃 <span id="c-leaf">0</span></div>
+      <div class="slot"><img id="c-bud" class="icon" src="assets/powerups/bud.svg" alt="Bud icon"/><span>0</span></div>
+      <div class="slot"><img id="c-golf" class="icon" src="assets/powerups/golf-cart.svg" alt="Golf cart icon"/><span>0</span></div>
+      <div class="slot"><img id="c-leaf" class="icon" src="assets/powerups/leaf.svg" alt="Leaf icon"/><span>0</span></div>
     </div>
 
     <div class="row">
@@ -804,7 +808,11 @@ function power(t){
   }
   renderCounts();
 }
-function renderCounts(){ cBud.textContent=counts.bud; cGolf.textContent=counts.golf; cLeaf.textContent=counts.leaf; }
+function renderCounts(){
+  cBud.nextElementSibling.textContent=counts.bud;
+  cGolf.nextElementSibling.textContent=counts.golf;
+  cLeaf.nextElementSibling.textContent=counts.leaf;
+}
 
 /* -------------------- Commentary -------------------- */
 let comT=null;


### PR DESCRIPTION
## Summary
- Inline SVG power-up icons with preloading for Bud, golf cart, and leaf blower pickups
- Render power-up counts in dedicated spans and style icons to scale with `em` units
- Set SVG assets to 1em sizing for consistent display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf6ea19a48329a6f86838195ee3aa