### PR TITLE
Add asset loading test for game assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/leaderboard.test.js"
+    "test": "node tests/assets.test.js && node tests/leaderboard.test.js"
   }
 }

--- a/tests/assets.test.js
+++ b/tests/assets.test.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { promises as fs } from 'fs';
+import path from 'path';
+import url from 'url';
+
+// Resolve directory of this test file
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+// Mock loadImage: returns a resolved Promise with provided src
+function loadImage(src) {
+  return Promise.resolve({ src });
+}
+
+// Build IMG object mapping asset names to mocked image promises
+async function buildIMG() {
+  const baseDir = path.resolve(__dirname, '..', 'assets');
+  const types = ['obstacles', 'powerups'];
+  const img = {};
+
+  for (const type of types) {
+    const dir = path.join(baseDir, type);
+    const files = await fs.readdir(dir);
+    for (const file of files) {
+      if (file.endsWith('.svg')) {
+        const key = file.replace('.svg', '');
+        const relPath = path.join('assets', type, file);
+        img[key] = loadImage(relPath);
+      }
+    }
+  }
+  return img;
+}
+
+const IMG = await buildIMG();
+const entries = Object.entries(IMG);
+assert.ok(entries.length > 0, 'IMG should contain entries');
+
+// Ensure every mocked image promise resolves
+await Promise.all(entries.map(async ([name, promise]) => {
+  const img = await promise;
+  assert.ok(img && img.src, `${name} should resolve with an object containing src`);
+}));
+
+console.log('assets IMG entries resolve');


### PR DESCRIPTION
## Summary
- add tests/assets.test.js that mocks `loadImage` and ensures asset promises resolve
- run new asset test alongside existing leaderboard test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf70c26e083298277be9c101057a5