### PR TITLE
Remove duplicate asset loader and standardize SVG paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,17 @@ const IMG={
   leaf: loadImg('assets/powerups/leaf.svg')
 };
 
+const assetsReady = Promise.all(
+  Object.values(IMG).map(img => new Promise(resolve => {
+    if (img.complete) {
+      resolve();
+    } else {
+      img.onload = resolve;
+      img.onerror = resolve;
+    }
+  }))
+);
+
 /* -------------------- Canvas (DPR + responsive scaling) -------------------- */
 const BASE_W=400, BASE_H=300; // internal game world
 const cvs=document.getElementById('gameCanvas'), ctx=cvs.getContext('2d');
@@ -644,33 +655,6 @@ function timeCheck(){
   if(left<=10 && (Math.floor(left*10)%5===0)) beep(900,.02,.06);
   if(elapsed>=limit) gameOver();
 }
-
-/* -------------------- Assets -------------------- */
-function loadImage(src){
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = reject;
-    img.src = src;
-  });
-}
-
-const IMG = {
-  rock: loadImage('assets/obstacles/rock.png'),
-  tree: loadImage('assets/obstacles/tree.png'),
-  sprinkler: loadImage('assets/obstacles/sprinkler.png'),
-  gnome: loadImage('assets/obstacles/gnome.png'),
-  flamingo: loadImage('assets/obstacles/flamingo.png'),
-  grill: loadImage('assets/obstacles/grill.png'),
-  chair: loadImage('assets/obstacles/chair.png'),
-  bucket: loadImage('assets/obstacles/bucket.png'),
-  bike: loadImage('assets/obstacles/bike.png'),
-  barrel: loadImage('assets/obstacles/barrel.png'),
-  shed: loadImage('assets/obstacles/shed.png'),
-  fountain: loadImage('assets/obstacles/fountain.png')
-};
-
-const assetsReady = Promise.all(Object.values(IMG));
 
 /* -------------------- World Gen + Bud spawner -------------------- */
 let limit=60;


### PR DESCRIPTION
## Summary
- remove redundant PNG-based image loader and IMG map
- await SVG assets via `assetsReady`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfc2f69a48329a011f069128b6dde