### PR TITLE
Skip level intro when name input focused

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,7 +467,10 @@ addEventListener('keydown',e=>{
   if(block.includes(e.code)) e.preventDefault();
   keys[e.key]=keys[e.code]=true;
   if(e.key==='p'||e.key==='P'||e.code==='Space') togglePause();
-  if(e.key==='Enter'&&!running) handleStartLevelClick();
+  if(e.key==='Enter'&&!running){
+    if(document.activeElement===playerName||landing.style.display!=='none') return;
+    handleStartLevelClick();
+  }
 });
 addEventListener('keyup',e=>{
   const block=['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','KeyW','KeyA','KeyS','KeyD'];

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/assets.test.js && node tests/leaderboard.test.js"
+    "test": "node tests/assets.test.js && node tests/leaderboard.test.js && node tests/enter-key-start.test.js"
   }
 }

--- a/tests/enter-key-start.test.js
+++ b/tests/enter-key-start.test.js
@@ -1,0 +1,51 @@
+import assert from 'assert';
+import { promises as fs } from 'fs';
+import path from 'path';
+import url from 'url';
+import vm from 'vm';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const html = await fs.readFile(path.resolve(__dirname, '../index.html'), 'utf8');
+
+function extractHandler(source, startPattern, name) {
+  const start = source.indexOf(startPattern);
+  const end = source.indexOf('});', start) + 3;
+  const snippet = source.slice(start, end);
+  return snippet
+    .replace(startPattern, `function ${name}(e){`)
+    .replace(/}\);$/, '}');
+}
+
+// Build global keydown handler function
+const keydownHandlerSrc = extractHandler(html, "addEventListener('keydown',e=>{", 'handler');
+// Build playerName keydown handler function
+const playerHandlerSrc = extractHandler(html, "playerName.addEventListener('keydown',e=>{", 'playerHandler');
+
+const context = {
+  keys: {},
+  running: false,
+  togglePause: () => {},
+  handleStartLevelClick: () => { context.handleCalls++; },
+  handleCalls: 0,
+  startGame: () => { context.startCalls++; context.landing.style.display = 'none'; },
+  startCalls: 0,
+  playerName: {},
+  landing: { style: { display: 'block' } },
+  document: { activeElement: null },
+  console
+};
+
+vm.createContext(context);
+vm.runInContext(keydownHandlerSrc, context);
+vm.runInContext(playerHandlerSrc, context);
+
+// Simulate Enter key press in name field
+const evt = { key: 'Enter', code: 'Enter', preventDefault: () => {} };
+context.document.activeElement = context.playerName;
+context.playerHandler(evt); // invokes startGame
+context.handler(evt); // global keydown handler
+
+assert.strictEqual(context.startCalls, 1, 'startGame should be called once');
+assert.strictEqual(context.handleCalls, 0, 'handleStartLevelClick should not be called');
+
+console.log('Enter key in name field starts game without level intro');


### PR DESCRIPTION
## Summary
- Avoid triggering level intro when pressing Enter in player-name field or while landing screen is visible
- Add regression test covering Enter key behavior in name field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c01b4cbb48329913bccb089f9cce5