### PR TITLE
Render world immediately after setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -757,6 +757,7 @@ function setup(level){
   bar.style.width='0%'; bar.textContent='0% Mowed';
   startLevelBtn.textContent='Start: '+L(level).n; startLevelBtn.disabled=false;
   pauseBtn.disabled=true; shareShot.style.display='none';
+  draw();
 }
 function weath(){ weatherEl.textContent = weather.type==='sun'?'☀️ Perfect':weather.type==='rain'?'🌧️ Rainy':'💨 Windy'; }
 


### PR DESCRIPTION
## Summary
- Add draw() call in setup to render world right after resetting Start/Pause buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c04e62d608329bf656b6baa0ab7bd