### PR TITLE
Auto start level after intro overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -929,6 +929,7 @@ function handleStartLevelClick(){
     introBody.textContent = rc(jokes);
     showOverlay(ovIntro);
     introShown=true;
+    setTimeout(()=>{ startLevelRun(); },400);
     return;
   }
   startLevelRun();


### PR DESCRIPTION
## Summary
- Automatically begin level 400ms after intro overlay appears, removing extra "Let's mow" click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c04e76b5c832984840c39835b089f