### PR TITLE
Refine canvas scaling logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,9 +449,9 @@ function fitCanvas(){
   // target CSS width: nearly full card width, but cap for sanity
   const app=document.getElementById('app');
   const maxCSS=Math.min(app.clientWidth-40, 860);       // padding aware
-  const cssW=Math.max(300, Math.floor(Math.min(maxCSS, window.innerWidth*0.95)));
-  const cssH=Math.floor(cssW*(BASE_H/BASE_W));
-  const scale=cssW/BASE_W;
+  const cssW=Math.max(320, Math.min(maxCSS, window.innerWidth * 0.95));
+  const scale=Math.max(0.5, cssW / BASE_W);
+  const cssH=BASE_H * scale;
 
   // set CSS size
   cvs.style.width=cssW+"px"; cvs.style.height=cssH+"px";


### PR DESCRIPTION
## Summary
- compute `cssW` using a wider minimum and remove flooring
- clamp rendering scale with a lower bound and derive height from it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0997b6c08329ab744fbbfc08f6ff