### PR TITLE
Auto-start first level automatically

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
   <h2 id="introTitle">Level Intro</h2>
   <p id="introDesc" class="desc" style="margin-top:0"></p>
   <p id="introBody" style="font-size:1.02rem"></p>
-  <div class="row"><button id="introGo" class="btn btn-primary">Let’s mow</button></div>
+  <div class="row"><button id="introGo" class="btn btn-primary">Skip intro</button></div>
 </div>
 
 <div class="overlay" id="ovChallenge">
@@ -965,7 +965,7 @@ async function startGame(){
   score=0; total=0; lvl=1; counts.bud=counts.golf=counts.leaf=0; renderCounts();
   landing.style.display='none'; game.style.display='block';
   hudName.textContent=name; hudBest.textContent=localStorage.getItem('clmc_best')||0;
-  setup(lvl); ui(); setComment("Welcome to Cainhoy. Tap Start when ready.");
+  setup(lvl); ui(); handleStartLevelClick(); setComment("Welcome to Cainhoy. Let's mow!");
 }
 function startLevel(){ handleStartLevelClick(); }
 

--- a/tests/enter-key-start.test.js
+++ b/tests/enter-key-start.test.js
@@ -27,7 +27,7 @@ const context = {
   togglePause: () => {},
   handleStartLevelClick: () => { context.handleCalls++; },
   handleCalls: 0,
-  startGame: () => { context.startCalls++; context.landing.style.display = 'none'; },
+  startGame: () => { context.startCalls++; context.landing.style.display = 'none'; context.handleStartLevelClick(); },
   startCalls: 0,
   playerName: {},
   landing: { style: { display: 'block' } },
@@ -46,6 +46,6 @@ context.playerHandler(evt); // invokes startGame
 context.handler(evt); // global keydown handler
 
 assert.strictEqual(context.startCalls, 1, 'startGame should be called once');
-assert.strictEqual(context.handleCalls, 0, 'handleStartLevelClick should not be called');
+assert.strictEqual(context.handleCalls, 1, 'handleStartLevelClick should be called once');
 
-console.log('Enter key in name field starts game without level intro');
+console.log('Enter key in name field starts game and level automatically');


### PR DESCRIPTION
## Summary
- Launch level intro and start immediately when the game begins.
- Replace intro overlay button text with "Skip intro" and remove instructions to tap start.
- Update tests for automatic level start on Enter.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c099439948329b7239ebad10e89f4