### PR TITLE
Fix duplicate startGame handler and add button test

### DIFF
--- a/index.html
+++ b/index.html
@@ -1128,11 +1128,6 @@ const introGo=document.getElementById('introGo');
 /* -------------------- Bindings -------------------- */
 function bind(){
   console.debug('bind(): attaching start game listeners');
-  document.addEventListener('click', (e) => {
-    const id = e.target?.id;
-    if(id==='startGameBtn'){ e.preventDefault(); startGame(); }
-    if(id==='startLevelBtn'){ e.preventDefault(); handleStartLevelClick(); }
-  }, { capture: true });
   startGameBtn.addEventListener('click',e=>{ e.preventDefault(); console.debug('startGameBtn click'); startGame(); });
   playerName.addEventListener('keydown',e=>{ if(e.key==='Enter'){ e.preventDefault(); console.debug('playerName Enter key'); startGame(); } });
   startLevelBtn.addEventListener('click',e=>{ e.preventDefault(); handleStartLevelClick(); });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node tests/assets.test.js && node tests/leaderboard.test.js && node tests/enter-key-start.test.js"
+    "test": "node tests/assets.test.js && node tests/leaderboard.test.js && node tests/enter-key-start.test.js && node tests/start-button.test.js"
   }
 }

--- a/tests/start-button.test.js
+++ b/tests/start-button.test.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import { promises as fs } from 'fs';
+import path from 'path';
+import url from 'url';
+import vm from 'vm';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const html = await fs.readFile(path.resolve(__dirname, '../index.html'), 'utf8');
+
+function extractHandler(source, startPattern, name) {
+  const start = source.indexOf(startPattern);
+  const end = source.indexOf('});', start) + 3;
+  const snippet = source.slice(start, end);
+  return snippet
+    .replace(startPattern, `function ${name}(e){`)
+    .replace(/}\);$/, '}');
+}
+
+// Build handlers
+const clickHandlerSrc = extractHandler(html, "startGameBtn.addEventListener('click',e=>{", 'btnHandler');
+const submitHandlerSrc = extractHandler(html, "startForm.addEventListener('submit',e=>{", 'submitHandler');
+
+const context = {
+  startCalls: 0,
+  startGame: () => { context.startCalls++; },
+  console
+};
+
+vm.createContext(context);
+vm.runInContext(clickHandlerSrc, context);
+vm.runInContext(submitHandlerSrc, context);
+
+// Simulate button click
+let defaultPrevented = false;
+const clickEvent = { preventDefault: () => { defaultPrevented = true; } };
+context.btnHandler(clickEvent);
+
+// Form submit should not fire when click prevented default
+if(!defaultPrevented) {
+  context.submitHandler({ preventDefault: () => {} });
+}
+
+assert.strictEqual(context.startCalls, 1, 'startGame should be called once');
+assert.strictEqual(defaultPrevented, true, 'form submission should be prevented');
+
+console.log('Start button calls startGame once without submitting form');


### PR DESCRIPTION
## Summary
- remove document-level click listener that triggered startGame twice
- add regression test ensuring Start button prevents form submit and calls startGame once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0ed8718883298b490be03c12c0c2