### PR TITLE
Prevent duplicate game start

### DIFF
--- a/index.html
+++ b/index.html
@@ -967,6 +967,7 @@ function genCongrats(player,level){
 
 /* -------------------- Level Flow -------------------- */
 async function startGame(){
+  if(running) return;
   const ASSET_TIMEOUT = 4000;
   const assetLoad = assetsReady
     .then(() => 'loaded')
@@ -1136,7 +1137,6 @@ const introGo=document.getElementById('introGo');
 function bind(){
   console.debug('bind(): attaching start game listeners');
   startGameBtn.addEventListener('click',e=>{ e.preventDefault(); console.debug('startGameBtn click'); startGame(); });
-  startForm.addEventListener('submit', e => { e.preventDefault(); startGame(); });
   playerName.addEventListener('keydown',e=>{ if(e.key==='Enter'){ e.preventDefault(); console.debug('playerName Enter key'); startGame(); } });
   startLevelBtn.addEventListener('click',e=>{ e.preventDefault(); handleStartLevelClick(); });
   introGo.addEventListener('click',startLevelRun);

--- a/tests/start-button.test.js
+++ b/tests/start-button.test.js
@@ -18,7 +18,6 @@ function extractHandler(source, startPattern, name) {
 
 // Build handlers
 const clickHandlerSrc = extractHandler(html, "startGameBtn.addEventListener('click',e=>{", 'btnHandler');
-const submitHandlerSrc = extractHandler(html, "startForm.addEventListener('submit',e=>{", 'submitHandler');
 
 const context = {
   startCalls: 0,
@@ -28,17 +27,11 @@ const context = {
 
 vm.createContext(context);
 vm.runInContext(clickHandlerSrc, context);
-vm.runInContext(submitHandlerSrc, context);
 
 // Simulate button click
 let defaultPrevented = false;
 const clickEvent = { preventDefault: () => { defaultPrevented = true; } };
 context.btnHandler(clickEvent);
-
-// Form submit should not fire when click prevented default
-if(!defaultPrevented) {
-  context.submitHandler({ preventDefault: () => {} });
-}
 
 assert.strictEqual(context.startCalls, 1, 'startGame should be called once');
 assert.strictEqual(defaultPrevented, true, 'form submission should be prevented');


### PR DESCRIPTION
## Summary
- Avoid multiple startGame triggers by guarding when the game is running
- Drop redundant start form submit handler in favor of button click and Enter key listeners
- Update start button test to reflect simplified handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc382effc8329bb19133adbb884b0