### PR TITLE
Disable automatic level start

### DIFF
--- a/index.html
+++ b/index.html
@@ -951,7 +951,6 @@ function handleStartLevelClick(){
     introBody.textContent = rc(jokes);
     showOverlay(ovIntro);
     introShown=true;
-    setTimeout(()=>{ startLevelRun(); },400);
     return;
   }
   startLevelRun();


### PR DESCRIPTION
## Summary
- Remove 400ms auto-start timeout in `handleStartLevelClick`
- Level now waits for "Skip intro" or user action before starting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc77307b48329ab5470d5475e02dc