### PR TITLE
Handle start via form submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,7 +483,7 @@ addEventListener('keydown',e=>{
   if(e.key==='p'||e.key==='P'||e.code==='Space') togglePause();
   if(e.key==='Enter'&&!running){
     if(landing.style.display!=='none'){
-      startGame();
+      if(!startForm.contains(document.activeElement)) startGame();
     }else if(document.activeElement!==playerName){
       handleStartLevelClick();
     }
@@ -1114,7 +1114,6 @@ const escapeHTML = s =>
 const landing=document.getElementById('landing');
 const game=document.getElementById('game');
 const playerName=document.getElementById('playerName');
-const startGameBtn=document.getElementById('startGameBtn');
 const startForm=document.getElementById('startForm');
 const startLevelBtn=document.getElementById('startLevelBtn');
 const pauseBtn=document.getElementById('pauseBtn');
@@ -1138,8 +1137,7 @@ const introGo=document.getElementById('introGo');
 /* -------------------- Bindings -------------------- */
 function bind(){
   console.debug('bind(): attaching start game listeners');
-  startGameBtn.addEventListener('click',e=>{ e.preventDefault(); console.debug('startGameBtn click'); startGame(); });
-  playerName.addEventListener('keydown',e=>{ if(e.key==='Enter'){ e.preventDefault(); console.debug('playerName Enter key'); startGame(); } });
+  startForm.addEventListener('submit', e => { e.preventDefault(); startGame(); });
   startLevelBtn.addEventListener('click',e=>{ e.preventDefault(); handleStartLevelClick(); });
   introGo.addEventListener('click',startLevelRun);
   pauseBtn.addEventListener('click',togglePause);

--- a/tests/enter-key-start.test.js
+++ b/tests/enter-key-start.test.js
@@ -16,34 +16,23 @@ function extractHandler(source, startPattern, name) {
     .replace(/}\);$/, '}');
 }
 
-// Build global keydown handler function
-const keydownHandlerSrc = extractHandler(html, "addEventListener('keydown',e=>{", 'handler');
-// Build playerName keydown handler function
-const playerHandlerSrc = extractHandler(html, "playerName.addEventListener('keydown',e=>{", 'playerHandler');
+// Build submit handler function
+const submitHandlerSrc = extractHandler(html, "startForm.addEventListener('submit', e => {", 'submitHandler');
 
 const context = {
-  keys: {},
-  running: false,
-  togglePause: () => {},
   handleStartLevelClick: () => { context.handleCalls++; },
   handleCalls: 0,
-  startGame: () => { context.startCalls++; context.landing.style.display = 'none'; context.handleStartLevelClick(); },
+  startGame: () => { context.startCalls++; context.handleStartLevelClick(); },
   startCalls: 0,
-  playerName: {},
-  landing: { style: { display: 'block' } },
-  document: { activeElement: null },
   console
 };
 
 vm.createContext(context);
-vm.runInContext(keydownHandlerSrc, context);
-vm.runInContext(playerHandlerSrc, context);
+vm.runInContext(submitHandlerSrc, context);
 
-// Simulate Enter key press in name field
-const evt = { key: 'Enter', code: 'Enter', preventDefault: () => {} };
-context.document.activeElement = context.playerName;
-context.playerHandler(evt); // invokes startGame
-context.handler(evt); // global keydown handler
+// Simulate Enter key press in name field via form submit
+const evt = { preventDefault: () => {} };
+context.submitHandler(evt);
 
 assert.strictEqual(context.startCalls, 1, 'startGame should be called once');
 assert.strictEqual(context.handleCalls, 1, 'handleStartLevelClick should be called once');

--- a/tests/start-button.test.js
+++ b/tests/start-button.test.js
@@ -17,7 +17,7 @@ function extractHandler(source, startPattern, name) {
 }
 
 // Build handlers
-const clickHandlerSrc = extractHandler(html, "startGameBtn.addEventListener('click',e=>{", 'btnHandler');
+const submitHandlerSrc = extractHandler(html, "startForm.addEventListener('submit', e => {", 'formHandler');
 
 const context = {
   startCalls: 0,
@@ -26,14 +26,14 @@ const context = {
 };
 
 vm.createContext(context);
-vm.runInContext(clickHandlerSrc, context);
+vm.runInContext(submitHandlerSrc, context);
 
-// Simulate button click
+// Simulate form submit
 let defaultPrevented = false;
-const clickEvent = { preventDefault: () => { defaultPrevented = true; } };
-context.btnHandler(clickEvent);
+const submitEvent = { preventDefault: () => { defaultPrevented = true; } };
+context.formHandler(submitEvent);
 
 assert.strictEqual(context.startCalls, 1, 'startGame should be called once');
 assert.strictEqual(defaultPrevented, true, 'form submission should be prevented');
 
-console.log('Start button calls startGame once without submitting form');
+console.log('Form submission calls startGame once without submitting form');


### PR DESCRIPTION
## Summary
- Start game through the start form's submit event instead of separate button/keydown handlers.
- Prevent duplicate starts by checking active element in the Enter key handler.
- Update tests for new form-driven behavior.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ccc4728e883299b995ba82234b7fc