### PR TITLE
Auto-start level after showing intro overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -951,6 +951,7 @@ function handleStartLevelClick(){
     introBody.textContent = rc(jokes);
     showOverlay(ovIntro);
     introShown=true;
+    setTimeout(startLevelRun, 1000); // auto-start after brief delay
     return;
   }
   startLevelRun();


### PR DESCRIPTION
## Summary
- Automatically launch gameplay after intro overlay by calling `startLevelRun` with a short delay, eliminating the need for a second click.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd32ba2e0832989c5d8f5aca30def