### PR TITLE
Normalize keydown handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -377,10 +377,11 @@ function resetInputState() {
 
 /* -------------------- Input Handling -------------------- */
 document.addEventListener('keydown', e => {
-  if(['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','w','a','s','d',' ','p'].includes(e.key.toLowerCase())) {
+  const k = e.key.toLowerCase();
+  if(['arrowup','arrowdown','arrowleft','arrowright','w','a','s','d',' ','p'].includes(k)) {
     e.preventDefault();
-    keys[e.key.toLowerCase()] = true;
-    if((e.key === 'p' || e.key === ' ') && gameState.running) togglePause();
+    keys[k] = true;
+    if((k === 'p' || k === ' ') && gameState.running) togglePause();
   }
 });
 


### PR DESCRIPTION
## Summary
- Normalize keydown processing to use lowercase comparisons
- Allow both 'p' and 'P' to toggle pause and prevent arrow key page scrolling

## Testing
- `node - <<'NODE' ... NODE` (simulate keydown events)
- `node tests/assets.test.js`
- `node tests/enter-key-start.test.js` *(fails: context.submitHandler is not a function)*
- `node tests/leaderboard.test.js`
- `node tests/start-button.test.js` *(fails: context.formHandler is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689d41c07ce88329a28bc8f4c5394155