### PR TITLE
refactor: cache start form element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1249,7 +1249,8 @@ function escapeHTML(s) {
 }
 
 /* -------------------- Event Bindings -------------------- */
-document.getElementById('startForm').addEventListener('submit', e => {
+const startForm = document.getElementById('startForm');
+startForm.addEventListener('submit', e => {
   e.preventDefault();
   startGame();
 });


### PR DESCRIPTION
## Summary
- cache start form element in `startForm` constant
- use cached form reference when binding submit handler

## Testing
- `node tests/enter-key-start.test.js`
- `node tests/start-button.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d4209f1a48329909878c966a90001