### PR TITLE
Add weekly leaderboard helper and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1221,13 +1221,24 @@ function loadLeaderboard() {
   }
 }
 
+function week(ts) {
+  const now = new Date();
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const day = start.getDay();
+  const diff = (day + 6) % 7;
+  start.setDate(start.getDate() - diff);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 7);
+  return ts >= start.getTime() && ts < end.getTime();
+}
+
 function showLeaderboard(filter = 'all') {
   const runs = loadRuns();
   let list = runs;
-  
+
   if(filter === 'week') {
-    const week = Date.now() - 7 * 24 * 60 * 60 * 1000;
-    list = runs.filter(r => r.ts > week);
+    list = runs.filter(r => week(r.ts));
   } else if(filter === 'you') {
     list = runs.filter(r => r.n === gameState.name);
   }
@@ -1249,7 +1260,8 @@ function escapeHTML(s) {
 }
 
 /* -------------------- Event Bindings -------------------- */
-document.getElementById('startForm').addEventListener('submit', e => {
+const startForm = document.getElementById('startForm');
+startForm.addEventListener('submit', e => {
   e.preventDefault();
   startGame();
 });


### PR DESCRIPTION
## Summary
- add `week(ts)` helper to compute current week boundaries and reuse in leaderboard filtering
- extract helper in tests to verify behavior across current, previous and next weeks
- define `startForm` constant for event binding

## Testing
- `for f in tests/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_689d4206cb24832994c39fd43ef951d9