### PR TITLE
Add arrow key state test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "charlies-lawn-mowing-adventure",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  }
+}

--- a/tests/arrow-keys.test.js
+++ b/tests/arrow-keys.test.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import { promises as fs } from 'fs';
+import path from 'path';
+import url from 'url';
+import vm from 'vm';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const html = await fs.readFile(path.resolve(__dirname, '../index.html'), 'utf8');
+
+function extractHandler(source, startPattern, name) {
+  const start = source.indexOf(startPattern);
+  const end = source.indexOf('});', start) + 3;
+  const snippet = source.slice(start, end);
+  return snippet
+    .replace(startPattern, `function ${name}(e){`)
+    .replace(/}\);$/, '}');
+}
+
+const keydownSrc = extractHandler(html, "document.addEventListener('keydown', e => {", 'handleKeyDown');
+const keyupSrc = extractHandler(html, "document.addEventListener('keyup', e => {", 'handleKeyUp');
+
+const context = { keys: {}, console };
+vm.createContext(context);
+vm.runInContext(`${keydownSrc}\n${keyupSrc}`, context);
+
+const evt = { key: 'ArrowLeft', preventDefault: () => {} };
+context.handleKeyDown(evt);
+assert.strictEqual(context.keys.arrowleft, true, 'ArrowLeft keydown should set keys.arrowleft true');
+
+context.handleKeyUp(evt);
+assert.strictEqual(context.keys.arrowleft, false, 'ArrowLeft keyup should set keys.arrowleft false');
+
+console.log('Arrow key handlers toggle keys.arrowleft correctly');


### PR DESCRIPTION
## Summary
- add unit test for arrow key handlers ensuring `keys.arrowleft` toggles on keydown and keyup
- define npm test script using Node's built-in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d4366d78c8329862626124455f7e7