### PR TITLE
Add persistent grass color variation with mowing shading

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,6 +380,29 @@ const ri = (a,b) => Math.floor(Math.random()*(b-a+1))+a;
 const rc = a => a[Math.floor(Math.random()*a.length)];
 const fmt = s => {const m=Math.floor(s/60),sec=Math.floor(s%60);return `${m}:${sec<10?"0":""}${sec}`};
 const hit = (a,b) => !(a.x+a.w<b.x||a.x>b.x+b.w||a.y+a.h<b.y||a.y>b.y+b.h);
+const clamp = (v,min,max) => Math.max(min, Math.min(max, v));
+const hexToRgb = hex => {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return m ? {r:parseInt(m[1],16), g:parseInt(m[2],16), b:parseInt(m[3],16)} : {r:0,g:0,b:0};
+};
+const rgbToHex = (r,g,b) => '#' + [r,g,b].map(v => v.toString(16).padStart(2,'0')).join('');
+const adjustColor = (hex, offset) => {
+  const {r,g,b} = hexToRgb(hex);
+  const f = 1 + offset;
+  return rgbToHex(
+    clamp(Math.round(r * f),0,255),
+    clamp(Math.round(g * f),0,255),
+    clamp(Math.round(b * f),0,255)
+  );
+};
+const blendColors = (c1,c2,ratio) => {
+  const a = hexToRgb(c1), b = hexToRgb(c2);
+  return rgbToHex(
+    Math.round(a.r + (b.r - a.r) * ratio),
+    Math.round(a.g + (b.g - a.g) * ratio),
+    Math.round(a.b + (b.b - a.b) * ratio)
+  );
+};
 
 /* -------------------- Cleanup -------------------- */
 function cleanupTimers() {
@@ -720,7 +743,7 @@ function setup(level) {
     for(let c = 0; c < 20; c++) {
       const x = c * ts, y = r * ts;
       if(r < 3 && c < 3) continue;
-      const tile = {x,y,w:ts,h:ts,m:false};
+      const tile = {x,y,w:ts,h:ts,m:false,o:(Math.random()*0.2-0.1)};
       if(!hit(tile, {x:260,y:20,w:110,h:90})) {
         tiles.push(tile);
       }
@@ -811,9 +834,11 @@ function draw() {
   
   // Draw grass tiles
   for(const t of tiles) {
-    ctx.fillStyle = t.m ? pal.mowedColor : pal.grassColor;
+    let col = adjustColor(pal.grassColor, t.o || 0);
+    if(t.m) col = blendColors(col, pal.mowedColor, 0.6);
+    ctx.fillStyle = col;
     ctx.fillRect(t.x, t.y, t.w, t.h);
-    
+
     // Tile border
     ctx.strokeStyle = 'rgba(0,0,0,0.1)';
     ctx.lineWidth = 1;


### PR DESCRIPTION
## Summary
- add color utility helpers for adjusting and blending colors
- cache random brightness offset per tile and blend toward a light cut color when mowed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d49f07f788329ad89887432a5dda1