### PR TITLE
Apply friction when mower crosses unmowed grass

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,6 +587,15 @@ function moveMower(dt) {
   mower.y += mower.vy * dt * fx;
   mower.x = Math.max(0, Math.min(BASE_W - mower.w, mower.x));
   mower.y = Math.max(0, Math.min(BASE_H - mower.h, mower.y));
+
+  // Fresh grass adds resistance; apply light friction on unmowed tiles
+  for(const t of tiles) {
+    if(!t.m && hit(mower, t)) {
+      mower.vx *= 0.95;
+      mower.vy *= 0.95;
+      break;
+    }
+  }
 }
 
 function checkTiles() {


### PR DESCRIPTION
## Summary
- Slow mower slightly when it moves over unmowed tiles to simulate resistance
- Document friction behavior in movement code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d49fb3ce88329b49610319c77762a