### PR TITLE
Add seasonal palette options

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,19 +260,21 @@
 <script>
 /* -------------------- Data -------------------- */
 const levels=[
-{n:"Barefoot Boulevard",d:"Toes out, dew cold, bottle caps everywhere.",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
-{n:"RAM Yard Test Track",d:"The Dodge RAM is blocking your line. Work around it.",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
-{n:"Golf Cart Grand Prix",d:"Shortcuts allowed. Avoid the welcome mat pothole.",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
-{n:"Trampoline Tangle",d:"Orbit the trampoline legs. No flips, all stripes.",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
-{n:"Edging Invitational",d:"Driveway, beds, sidewalk. Sharp lines only.",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
-{n:"Blower Showdown",d:"Blast corners clean. Leave no crumb behind.",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
-{n:"EGO vs Husky Derby",d:"Talks smack about electric, borrows EGO anyway.",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
-{n:"Budweiser Yard Party",d:"Mow around the coolers. Cans are not power ups.",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
-{n:"Cainhoy Dollar Tree HOA Finals",d:"Every neighbor is judging the stripes.",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}},
-{n:"Lowcountry Crosswind",d:"Cainhoy gusts push your deck. Hold the line.",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}},
-{n:"Overtime Overgrowth",d:"Bonus jungle. The clippings will tell your story.",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}},
-{n:"Golden Grass Champion",d:"Perfect pass, perfect blow, perfect edge.",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}}
+{n:"Barefoot Boulevard",d:"Toes out, dew cold, bottle caps everywhere.",season:"spring",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
+{n:"RAM Yard Test Track",d:"The Dodge RAM is blocking your line. Work around it.",season:"spring",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
+{n:"Golf Cart Grand Prix",d:"Shortcuts allowed. Avoid the welcome mat pothole.",season:"spring",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
+{n:"Trampoline Tangle",d:"Orbit the trampoline legs. No flips, all stripes.",season:"spring",palette:{grassColor:"#7CFC00",mowedColor:"#90EE90",skyColor:"#87CEEB"}},
+{n:"Edging Invitational",d:"Driveway, beds, sidewalk. Sharp lines only.",season:"summer",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
+{n:"Blower Showdown",d:"Blast corners clean. Leave no crumb behind.",season:"summer",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
+{n:"EGO vs Husky Derby",d:"Talks smack about electric, borrows EGO anyway.",season:"summer",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
+{n:"Budweiser Yard Party",d:"Mow around the coolers. Cans are not power ups.",season:"summer",palette:{grassColor:"#C2B280",mowedColor:"#DEB887",skyColor:"#FFDAB9"}},
+{n:"Cainhoy Dollar Tree HOA Finals",d:"Every neighbor is judging the stripes.",season:"autumn",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}},
+{n:"Lowcountry Crosswind",d:"Cainhoy gusts push your deck. Hold the line.",season:"autumn",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}},
+{n:"Overtime Overgrowth",d:"Bonus jungle. The clippings will tell your story.",season:"autumn",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}},
+{n:"Golden Grass Champion",d:"Perfect pass, perfect blow, perfect edge.",season:"autumn",palette:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8",skyColor:"#B0E0E6"}}
 ];
+
+const seasonPalettes={spring:{grassColor:"#7CFC00",mowedColor:"#90EE90"},summer:{grassColor:"#C2B280",mowedColor:"#DEB887"},autumn:{grassColor:"#E0F8FF",mowedColor:"#F8FFF8"}};
 
 const introsByLevel=[
   ["Charlie kicks off his sandals and tells the lawn behave. The lawn refuses. You accept."],
@@ -710,6 +712,7 @@ function setup(level) {
   
   const lvlData = levels[Math.min(level - 1, levels.length - 1)];
   pal = lvlData.palette;
+  if(lvlData.season&&seasonPalettes[lvlData.season]) pal={...pal,...seasonPalettes[lvlData.season]};
   
   // Add house
   obs.push({t:'house',a:true,x:260,y:20,w:110,h:90});


### PR DESCRIPTION
## Summary
- add optional `season` field to levels
- map seasons to grass and mowed colors
- update setup to apply seasonal palettes with default fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d4a025e2883299c42db8d7100c97f