### PR TITLE
Refactor mower sprite loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,18 +963,24 @@ function setup(level) {
 
 /* -------------------- Sprites -------------------- */
 const spriteSvgs = {
-  mower: `<svg viewBox='0 0 32 16' xmlns='http://www.w3.org/2000/svg'><rect x='1' y='1' width='14' height='14' rx='2' fill='#4caf50'/><rect x='4' y='4' width='8' height='6' fill='#fff'/><circle cx='4' cy='14' r='2' fill='#555'/><circle cx='12' cy='14' r='2' fill='#555'/><rect x='17' y='1' width='14' height='14' rx='2' fill='#4caf50'/><rect x='20' y='4' width='8' height='6' fill='#fff'/><circle cx='20' cy='14' r='2' fill='#555'/><circle cx='28' cy='14' r='2' fill='#555'/></svg>`,
-  house: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><path d='M8 28 L32 8 L56 28 Z' fill='#b5651d'/><rect x='14' y='28' width='36' height='28' rx='3' fill='#d9d9d9' stroke='#555'/><rect x='28' y='40' width='10' height='16' fill='#9ecae1'/></svg>`,
-  rock: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><ellipse cx='32' cy='40' rx='22' ry='14' fill='#777'/><ellipse cx='28' cy='34' rx='10' ry='6' fill='#888'/></svg>`,
-  tree: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><rect x='28' y='34' width='8' height='18' fill='#8b5a2b'/><circle cx='32' cy='28' r='18' fill='#2e7d32'/></svg>`,
-  sprinkler: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><rect x='28' y='44' width='8' height='8' fill='#444'/><path d='M16 40 Q32 24 48 40' stroke='#4fc3f7' stroke-width='4' fill='none'/></svg>`,
-  gnome: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><path d='M32 8 L44 24 H20 Z' fill='#e53935'/><circle cx='32' cy='30' r='8' fill='#ffe0b2'/><rect x='20' y='38' width='24' height='16' fill='#1976d2'/></svg>`,
-  flamingo: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><circle cx='24' cy='28' r='10' fill='#ff6ea2'/><rect x='22' y='38' width='4' height='16' fill='#ff6ea2'/><rect x='34' y='24' width='16' height='8' rx='4' fill='#ff6ea2'/></svg>`,
-  grill: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><ellipse cx='32' cy='28' rx='18' ry='12' fill='#222'/><rect x='14' y='28' width='36' height='6' fill='#333'/><rect x='30' y='34' width='4' height='16' fill='#222'/></svg>`,
-  chair: `<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><rect x='18' y='22' width='28' height='8' fill='#90caf9'/><rect x='18' y='30' width='28' height='12' fill='#e3f2fd'/><rect x='20' y='42' width='4' height='12' fill='#90caf9'/><rect x='42' y='42' width='4' height='12' fill='#90caf9'/></svg>`
+  mowerV: `<svg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><rect x='1' y='1' width='14' height='14' rx='2' fill='#4caf50'/><rect x='4' y='4' width='8' height='6' fill='#fff'/><circle cx='4' cy='14' r='2' fill='#555'/><circle cx='12' cy='14' r='2' fill='#555'/></svg>`
+  mowerH: `<svg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><rect x='1' y='1' width='14' height='14' rx='2' fill='#4caf50'/><rect x='4' y='4' width='6' height='8' fill='#fff'/><circle cx='14' cy='4' r='2' fill='#555'/><circle cx='14' cy='12' r='2' fill='#555'/></svg>`
+  house: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><path d='M8 28 L32 8 L56 28 Z' fill='#b5651d'/><rect x='14' y='28' width='36' height='28' rx='3' fill='#d9d9d9' stroke='#555'/><rect x='28' y='40' width='10' height='16' fill='#9ecae1'/></svg>`
+  rock: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><ellipse cx='32' cy='40' rx='22' ry='14' fill='#777'/><ellipse cx='28' cy='34' rx='10' ry='6' fill='#888'/></svg>`
+  tree: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><rect x='28' y='34' width='8' height='18' fill='#8b5a2b'/><circle cx='32' cy='28' r='18' fill='#2e7d32'/></svg>`
+  sprinkler: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><rect x='28' y='44' width='8' height='8' fill='#444'/><path d='M16 40 Q32 24 48 40' stroke='#4fc3f7' stroke-width='4' fill='none'/></svg>`
+  gnome: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><path d='M32 8 L44 24 H20 Z' fill='#e53935'/><circle cx='32' cy='30' r='8' fill='#ffe0b2'/><rect x='20' y='38' width='24' height='16' fill='#1976d2'/></svg>`
+  flamingo: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><circle cx='24' cy='28' r='10' fill='#ff6ea2'/><rect x='22' y='38' width='4' height='16' fill='#ff6ea2'/><rect x='34' y='24' width='16' height='8' rx='4' fill='#ff6ea2'/></svg>`
+  grill: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><ellipse cx='32' cy='28' rx='18' ry='12' fill='#222'/><rect x='14' y='28' width='36' height='6' fill='#333'/><rect x='30' y='34' width='4' height='16' fill='#222'/></svg>`
+  chair: `<svg width='64' height='64' viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><rect x='18' y='22' width='28' height='8' fill='#90caf9'/><rect x='18' y='30' width='28' height='12' fill='#e3f2fd'/><rect x='20' y='42' width='4' height='12' fill='#90caf9'/><rect x='42' y='42' width='4' height='12' fill='#90caf9'/></svg>`
 };
 const sprites = {};
-function makeImage(svg){ const img = new Image(); img.src = 'data:image/svg+xml;utf8,' + encodeURIComponent(svg); return img; }
+function makeImage(svg){
+  const img = new Image();
+  const encoded = typeof btoa === 'function' ? btoa(svg) : Buffer.from(svg).toString('base64');
+  img.src = 'data:image/svg+xml;base64,' + encoded;
+  return img;
+}
 function buildSprites(){ for(const [k,svg] of Object.entries(spriteSvgs)){ sprites[k] = makeImage(svg); } }
 function drawSprite(type,x,y,w,h){ const img = sprites[type]; if(img && img.complete){ ctx.drawImage(img,x,y,w,h); return true; } return false; }
 
@@ -1081,21 +1087,29 @@ function drawMower() {
     }
   }
 
-  const img = sprites.mower;
-  if(img && img.complete) {
-    ctx.save();
-    ctx.translate(m.x + m.w/2, m.y + m.h/2);
-    let sx = 0;
+  const key = (m.dir === 'left' || m.dir === 'right') ? 'mowerH' : 'mowerV';
+  const img = sprites[key];
+  ctx.save();
+  ctx.translate(m.x + m.w/2, m.y + m.h/2);
+  if(m.dir === 'left') ctx.scale(-1, 1);
+  else if(m.dir === 'down') ctx.rotate(Math.PI);
+  if(img && img.naturalWidth && img.complete) {
+    ctx.drawImage(img, -m.w/2, -m.h/2, m.w, m.h);
+  } else {
+    ctx.fillStyle = '#4caf50';
+    ctx.fillRect(-m.w/2, -m.h/2, m.w, m.h);
+    ctx.fillStyle = '#555';
+    ctx.beginPath();
     if(m.dir === 'left' || m.dir === 'right') {
-      sx = 16;
-      if(m.dir === 'left') ctx.scale(-1, 1);
+      ctx.arc(m.w/2 - 2, -m.h/2 + 4, 2, 0, Math.PI*2);
+      ctx.arc(m.w/2 - 2, m.h/2 - 4, 2, 0, Math.PI*2);
     } else {
-      sx = 0;
-      if(m.dir === 'down') ctx.rotate(Math.PI);
+      ctx.arc(-m.w/2 + 4, m.h/2 - 2, 2, 0, Math.PI*2);
+      ctx.arc(m.w/2 - 4, m.h/2 - 2, 2, 0, Math.PI*2);
     }
-    ctx.drawImage(img, sx, 0, 16, 16, -m.w/2, -m.h/2, m.w, m.h);
-    ctx.restore();
+    ctx.fill();
   }
+  ctx.restore();
 
   // Power-up indicators
   if(m.boost) {


### PR DESCRIPTION
## Summary
- Base64-encode SVG sprites with explicit width and height
- Replace mower sprite sheet with vertical and horizontal versions
- Fallback to a simple canvas placeholder if mower image fails to load

## Testing
- `npm test`
- ⚠️ Manual verification on required browsers not run in container

------
https://chatgpt.com/codex/tasks/task_e_689e03f16c2483298d22c333c618ccd3